### PR TITLE
Fix marketplace plugin source path validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
       "name": "claude-code-hetzner-vps",
       "description": "Provision secure, Claude Code-ready Hetzner VPS instances with auto-firewall, fail2ban, and SSH hardening. See costs before you spend. A free tool by The Resonance.",
       "version": "1.0.0",
-      "source": ".",
+      "source": "./",
       "author": {
         "name": "Pete Sena",
         "email": "pete@theresonance.studio",


### PR DESCRIPTION
## Summary
- Fix schema validation error when installing plugin via marketplace
- Change `source` field from `"."` to `"./"` to satisfy Claude Code's schema validation requirement

## Problem
Users attempting to install via `/plugin marketplace add The-Resonance/claude-code-hetzner-vps` received:
```
Error: Invalid schema: plugins.0.source: Invalid input: must start with "./"
```

## Solution
The schema validator requires paths to explicitly start with `"./"`. Updated `.claude-plugin/marketplace.json` accordingly.

## Testing
- [x] JSON validates correctly
- [x] Plugin loads without errors locally
- [ ] Marketplace installation from GitHub (pending merge)

Fixes #1