### PR TITLE
Add issue templates and contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report something that isn't working correctly
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of what the bug is.
+
+## Steps to Reproduce
+
+1. Run command '...'
+2. See error '...'
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- OS: [e.g., macOS 14.0, Ubuntu 22.04]
+- Claude Code version: [e.g., 2.0.12]
+- hcloud CLI version: [run `hcloud version`]
+
+## Additional Context
+
+Any other relevant information (error logs, screenshots, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://claude-code-hetzner.vercel.app/
+    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this plugin
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem are you trying to solve? What's missing?
+
+## Proposed Solution
+
+How would you like this to work?
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've thought about.
+
+## Additional Context
+
+Any other relevant information or screenshots.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ tmp/
 
 # Cloud-init generated files
 user-data-*.yaml
+
+# Local Claude instructions (not for repo)
+CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Thanks for your interest in contributing to claude-code-hetzner-vps!
+
+## How to Contribute
+
+### Reporting Bugs
+
+1. Check [existing issues](https://github.com/The-Resonance/claude-code-hetzner-vps/issues) first
+2. Use the bug report template
+3. Include steps to reproduce
+
+### Suggesting Features
+
+1. Open an issue using the feature request template
+2. Describe the problem you're solving
+3. Propose your solution
+
+### Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feat/my-feature`)
+3. Make your changes
+4. Test locally with `claude --plugin-dir .`
+5. Commit with clear messages
+6. Push to your fork
+7. Open a Pull Request against `main`
+
+## Development Setup
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/claude-code-hetzner-vps.git
+cd claude-code-hetzner-vps
+
+# Test the plugin
+claude --plugin-dir .
+
+# Try commands
+/provision --help
+/cost-estimate cx22
+```
+
+## Code Style
+
+- Keep scripts simple and readable
+- Add comments for non-obvious logic
+- Test changes before submitting
+
+## Questions?
+
+Open an issue or reach out to [Pete Sena](https://linkedin.com/in/petersena).


### PR DESCRIPTION
## Summary

Polish the repository for public consumption:

- Add GitHub issue templates (bug report, feature request)
- Add `CONTRIBUTING.md` with development setup guide
- Update `.gitignore` for local Claude instructions

## Repo Settings Also Updated

- Added topics: `claude-code`, `hetzner`, `vps`, `devops`, `security`, `plugin`, `cloud`, `infrastructure`, `automation`
- Set homepage to https://claude-code-hetzner.vercel.app/
- Disabled unused wiki
- Enabled branch protection on main